### PR TITLE
Feature/w3b-93 allow to pull rewards from the reward vault if we missed a day

### DIFF
--- a/docs/rewardvault.md
+++ b/docs/rewardvault.md
@@ -19,3 +19,5 @@ Holds all the rewards that will be distributed by the RewardPool contract.
  - The owner can only control who is authorized to pull rewards
  - The release schedule cannot be changed
  - Tokens can be sent to this contract at any time and will be released based on a schedule which follows the [Token Emissions](./emissions.md)
+ - Tokens are released on daily intervals from the firs release
+ - If tokens are not pulled for `n` days then the next time tokens are pulled the contract will release tokens for `n+1` days

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -24,6 +24,7 @@ function getRemappings() {
 export const compilerConfig = (version: string) => ({
   version,
   settings: {
+    evmVersion: 'london',
     optimizer: {
       enabled: true,
       runs: 5000
@@ -48,6 +49,11 @@ const hardhatConfig: HardhatUserConfig = {
       chainId: 5,
       url: "",
       accounts: []
+    },
+    arbitrumGoerli: {
+      chainId: 421613,
+      url: "https://goerli-rollup.arbitrum.io/rpc",
+      accounts: ['0xafd72e8b21617468e50f211f985267ca8eeed3732875e2853e6219d53938b074']
     }
     // mumbai: {
     //   url: process.env.NODE_URL || `https://polygon-mumbai.g.alchemy.com/v2/${envConfig.ALCHEMY_API_KEY}`,

--- a/test/rewardPool.spec.ts
+++ b/test/rewardPool.spec.ts
@@ -727,7 +727,7 @@ describe('RewardPool', () => {
           updatedProof = updatedMerkleTree.getProof(i);
         }
       }
-      time.increase(90000);
+      await time.increase(90000);
       await rewardPool
         .connect(distributor)
         .submitMerkleRoot(updatedRoot, ethers.utils.parseEther(String(14_246)));


### PR DESCRIPTION
## Problem Description

If rewards were not pulled from the reward vault one day then it was impossible to pull those rewards afterwards and the emission schedule was getting out of sync.

## Solution

Instead of just checking when rewards were last pulled we now check how many times rewards have been given since the first time, so if for `n` days we do not pull rewards then the next time we pull we will pull rewards for `n+1` days.

## Checklist

Please make sure to review and check the following before submitting the pull request:

- [x] Unit tests are added or modified to cover the changes.
- [x] Documentation has been updated to reflect the changes.
