### PR TITLE
feat: remove pausability from erc-20 token

### DIFF
--- a/docs/weatherxm.md
+++ b/docs/weatherxm.md
@@ -1,8 +1,7 @@
 # WeatherXM
 
-The token of the WeatherXM ecosystem. Its a standard ERC20 token with a max supply of 100M that is minted on deployment to the deployer’s address. The token allows for token burning and is also pausable. No mint is allowed even after tokens are burned. The token is using the following base contracts from [Openzeppelin](https://github.com/OpenZeppelin/openzeppelin-contracts):
+The token of the WeatherXM ecosystem. Its a standard ERC20 token with a max supply of 100M that is minted on deployment to the deployer’s address. The token allows for token burning. No mint is allowed even after tokens are burned. The token is using the following base contracts from [Openzeppelin](https://github.com/OpenZeppelin/openzeppelin-contracts):
 
 - `ERC20`
 - `ERC20Capped`
-- `Pausable`
 - `Ownable`

--- a/src/WeatherXM.sol
+++ b/src/WeatherXM.sol
@@ -4,10 +4,9 @@ pragma solidity 0.8.20;
 import { SafeMath } from "lib/openzeppelin-contracts/contracts/utils/math/SafeMath.sol";
 import { ERC20 } from "lib/openzeppelin-contracts/contracts/token/ERC20/ERC20.sol";
 import { ERC20Capped } from "lib/openzeppelin-contracts/contracts/token/ERC20/extensions/ERC20Capped.sol";
-import { Pausable } from "lib/openzeppelin-contracts/contracts/security/Pausable.sol";
 import { Ownable } from "lib/openzeppelin-contracts/contracts/access/Ownable.sol";
 
-contract WeatherXM is Pausable, ERC20, ERC20Capped, Ownable {
+contract WeatherXM is ERC20, ERC20Capped, Ownable {
   /* ========== LIBRARIES ========== */
   using SafeMath for uint256;
 
@@ -21,28 +20,20 @@ contract WeatherXM is Pausable, ERC20, ERC20Capped, Ownable {
     _mint(_msgSender(), maxSupply);
   }
 
-  function burn(uint256 amount) external whenNotPaused {
+  function burn(uint256 amount) external {
     super._burn(_msgSender(), amount);
   }
 
-  function burnFrom(address account, uint256 amount) external whenNotPaused {
+  function burnFrom(address account, uint256 amount) external {
     super._spendAllowance(account, _msgSender(), amount);
     super._burn(account, amount);
-  }
-
-  function pause() external onlyOwner {
-    super._pause();
-  }
-
-  function unpause() external onlyOwner {
-    super._unpause();
   }
 
   function _mint(address account, uint256 amount) internal override(ERC20, ERC20Capped) {
     ERC20Capped._mint(account, amount);
   }
 
-  function _beforeTokenTransfer(address from, address to, uint256 amount) internal virtual override whenNotPaused {
+  function _beforeTokenTransfer(address from, address to, uint256 amount) internal virtual override {
     super._beforeTokenTransfer(from, to, amount);
   }
 }

--- a/src/interfaces/IWeatherXM.sol
+++ b/src/interfaces/IWeatherXM.sol
@@ -7,10 +7,6 @@ interface IWeatherXM is IERC20Metadata {
 
   function burn(uint256 amount) external;
 
-  function pause() external;
-
-  function unpause() external;
-
   function owner() external view returns (address);
 
   function totalSupply() external view returns (uint256);

--- a/test/foundry/WeatherXM.t.sol
+++ b/test/foundry/WeatherXM.t.sol
@@ -134,45 +134,4 @@ contract WeatherXMTest is Test {
       expRevertMessage: "ERC20: transfer to the zero address"
     });
   }
-
-  function testPausedTransfer() public {
-    vm.startPrank(admin);
-    vm.deal(admin, 1 ether);
-    weatherXM.transfer(alice, 35);
-    weatherXM.pause();
-    vm.stopPrank();
-    vm.expectRevert("Pausable: paused");
-    transferToken(alice, bob, 35);
-  }
-
-  function testPausedBurn() public {
-    vm.startPrank(admin);
-    vm.deal(admin, 1 ether);
-    weatherXM.transfer(alice, 35);
-    weatherXM.pause();
-    vm.stopPrank();
-    vm.expectRevert("Pausable: paused");
-    vm.startPrank(alice);
-    weatherXM.burn(35);
-    vm.stopPrank();
-  }
-
-   function testUnpause() public {
-    vm.startPrank(admin);
-    vm.deal(admin, 1 ether);
-    weatherXM.transfer(alice, 35);
-    weatherXM.pause();
-    vm.stopPrank();
-    vm.expectRevert("Pausable: paused");
-    transferToken(alice, bob, 35);
-    vm.startPrank(admin);
-    weatherXM.unpause();
-    vm.stopPrank();
-
-    vm.startPrank(alice);
-    weatherXM.transfer(bob, 35);
-    vm.stopPrank();
-    assertEq(weatherXM.balanceOf(alice), 0);
-    assertEq(weatherXM.balanceOf(bob), 35);
-  }
 }


### PR DESCRIPTION
## Problem Description

The bridged Arbitrum token will not be pausable so it makes no sense for the Eth mainnet side token to be pausable

## Solution

Remove plausibility from the WeatherXM ERC-20 token

## Related Issues

<!-- If this pull request is related to any existing issues, reference them here using the GitHub issue syntax (e.g., "Fixes #123"). -->

## Checklist

Please make sure to review and check the following before submitting the pull request:

- [x] Unit tests are added or modified to cover the changes.
- [x] Documentation has been updated to reflect the changes.
