### PR TITLE
feat: allow submitting multiple root hases if submitions were missed

### DIFF
--- a/src/RewardPool.sol
+++ b/src/RewardPool.sol
@@ -44,24 +44,30 @@ contract RewardPool is
   uint256 public claimedRewards;
   IRewardsVault public rewardsVault;
   address public rewardsChangeTreasury;
+  uint256 public firstRewardCycleTs;
 
   /* ========== ROLES ========== */
   bytes32 public constant DISTRIBUTOR_ROLE = keccak256("DISTRIBUTOR_ROLE");
   bytes32 public constant UPGRADER_ROLE = keccak256("UPGRADER_ROLE");
 
-  uint public constant MAX_CLAIM_WAIT_PERIOD = 3600;
+  /* ========== CONSTANTS ========== */
+  uint256 public constant merkleRootSubmissionPeriod = 1440 minutes;
 
   /**
    * @notice Rate limit for submitting root hashes.
    * @dev Every 24h is the minimum limit for submitting root hashes for rewards
    * due to the fact that every 24h, the minting is going to take place for the first 10ys
-   * @param period The period for which to enforce the rate limit
    * */
-  modifier rateLimit(uint256 period) {
-    if (block.timestamp < lastRewardRootTs) {
-      revert RewardsRateLimitingInEffect();
+  modifier rateLimit() {
+    if (firstRewardCycleTs == 0) {
+      firstRewardCycleTs = block.timestamp;
+    } else {
+      uint256 currCycle = getCurrCycle();
+
+      if (cycle >= currCycle) {
+        revert RewardsRateLimitingInEffect();
+      }
     }
-    lastRewardRootTs = lastRewardRootTs.add(period);
     _;
   }
 
@@ -100,6 +106,12 @@ contract RewardPool is
     rewardsChangeTreasury = _rewardsChangeTreasury;
   }
 
+  function getCurrCycle() public view returns (uint256) {
+    uint256 currCycle = ((block.timestamp - firstRewardCycleTs) / merkleRootSubmissionPeriod) + 1;
+
+    return currCycle;
+  }
+
   /**
    * @notice Submit root hash for rewards.
    * @dev The root hash is calculated of chain and submitted every day.
@@ -108,11 +120,14 @@ contract RewardPool is
    * The root hashes are stored in a mapping where the cycle is the accessor.
    * For every cycle there is only one root hash.
    * @param root The root hash containing the cumulative rewards plus the daily rewards.
+   * @param totalRewards The total rewads being allocation with this merkle root.
+   * @param boostRewards The amount of rewards that are being allocated as part of a boost.
    * */
   function submitMerkleRoot(
     bytes32 root,
-    uint256 totalRewards
-  ) external override onlyRole(DISTRIBUTOR_ROLE) rateLimit(1440 minutes) whenNotPaused returns (bool) {
+    uint256 totalRewards,
+    uint256 boostRewards
+  ) external override onlyRole(DISTRIBUTOR_ROLE) rateLimit whenNotPaused returns (bool) {
     uint256 activeCycle = cycle;
     roots[activeCycle] = root;
 
@@ -123,8 +138,13 @@ contract RewardPool is
 
     // The rewards vault will always send as much as it has up to the daily emissions amount.
     // If are distributing less than the daily emission send the change to the treasury.
-    if (delta > totalRewards) {
+    // The boost is coming from a different pool so it doesnt count again the change
+    if (delta - boostRewards > totalRewards) {
       token.safeTransfer(rewardsChangeTreasury, delta - totalRewards);
+    }
+
+    if (boostRewards > 0) {
+      token.safeTransferFrom(rewardsChangeTreasury, address(this), boostRewards);
     }
 
     cycle++;

--- a/src/interfaces/IRewardPool.sol
+++ b/src/interfaces/IRewardPool.sol
@@ -42,7 +42,7 @@ interface IRewardPool {
   event RequestClaim(address indexed from, uint256 amount);
 
   //root hash submission
-  function submitMerkleRoot(bytes32 root, uint256 totalRewards) external returns (bool);
+  function submitMerkleRoot(bytes32 root, uint256 totalRewards, uint256 boostRewards) external returns (bool);
 
   // transfer functions
   function transferRewards(

--- a/test/foundry/RewardPool.t.sol
+++ b/test/foundry/RewardPool.t.sol
@@ -116,7 +116,7 @@ contract RewardPoolTest is Test {
     wrappedProxyV1.grantRole(DISTRIBUTOR_ROLE, bob);
     vm.stopPrank();
     vm.startPrank(bob);
-    wrappedProxyV1.submitMerkleRoot(root, maxDailyEmission);
+    wrappedProxyV1.submitMerkleRoot(root, maxDailyEmission, 0);
     for (uint i = 0; i < leaves.length; ++i) {
       RLPReader.RLPItem[] memory rewards = resultData.toRlpItem().toList();
       RLPReader.RLPItem[] memory proofsEncoded = resultProofs.toRlpItem().toList();
@@ -141,7 +141,7 @@ contract RewardPoolTest is Test {
     wrappedProxyV1.grantRole(DISTRIBUTOR_ROLE, bob);
     vm.stopPrank();
     vm.startPrank(bob);
-    wrappedProxyV1.submitMerkleRoot(root, maxDailyEmission);
+    wrappedProxyV1.submitMerkleRoot(root, maxDailyEmission, 0);
     for (uint i = 0; i < leaves.length; ++i) {
       RLPReader.RLPItem[] memory rewards = resultData.toRlpItem().toList();
       RLPReader.RLPItem[] memory proofsEncoded = resultProofs.toRlpItem().toList();
@@ -166,7 +166,7 @@ contract RewardPoolTest is Test {
     wrappedProxyV1.grantRole(DISTRIBUTOR_ROLE, bob);
     vm.stopPrank();
     vm.startPrank(bob);
-    wrappedProxyV1.submitMerkleRoot(root, maxDailyEmission);
+    wrappedProxyV1.submitMerkleRoot(root, maxDailyEmission, 0);
     RLPReader.RLPItem[] memory rewards = resultData.toRlpItem().toList();
     RLPReader.RLPItem[] memory proofsEncoded = resultProofs.toRlpItem().toList();
     bytes32[] memory _proof = new bytes32[](proofsEncoded[0].toList().length);
@@ -192,7 +192,7 @@ contract RewardPoolTest is Test {
     wrappedProxyV1.grantRole(DISTRIBUTOR_ROLE, bob);
     vm.stopPrank();
     vm.startPrank(bob);
-    wrappedProxyV1.submitMerkleRoot(root, maxDailyEmission);
+    wrappedProxyV1.submitMerkleRoot(root, maxDailyEmission, 0);
     RLPReader.RLPItem[] memory rewards = resultData.toRlpItem().toList();
     RLPReader.RLPItem[] memory proofsEncoded = resultProofs.toRlpItem().toList();
     bytes32[] memory _proof = new bytes32[](proofsEncoded[0].toList().length);
@@ -225,7 +225,7 @@ contract RewardPoolTest is Test {
     wrappedProxyV1.grantRole(DISTRIBUTOR_ROLE, bob);
     vm.stopPrank();
     vm.startPrank(bob);
-    wrappedProxyV1.submitMerkleRoot(root, maxDailyEmission);
+    wrappedProxyV1.submitMerkleRoot(root, maxDailyEmission, 0);
     RLPReader.RLPItem[] memory rewards = resultData.toRlpItem().toList();
     RLPReader.RLPItem[] memory proofsEncoded = resultProofs.toRlpItem().toList();
     bytes32[] memory _proof = new bytes32[](proofsEncoded[0].toList().length);
@@ -251,7 +251,7 @@ contract RewardPoolTest is Test {
     wrappedProxyV1.grantRole(DISTRIBUTOR_ROLE, bob);
     vm.stopPrank();
     vm.startPrank(bob);
-    wrappedProxyV1.submitMerkleRoot(root, maxDailyEmission);
+    wrappedProxyV1.submitMerkleRoot(root, maxDailyEmission, 0);
     RLPReader.RLPItem[] memory rewards = resultData.toRlpItem().toList();
     RLPReader.RLPItem[] memory proofsEncoded = resultProofs.toRlpItem().toList();
     bytes32[] memory _proof = new bytes32[](proofsEncoded[0].toList().length);
@@ -296,7 +296,7 @@ contract RewardPoolTest is Test {
     wrappedProxyV1.grantRole(DISTRIBUTOR_ROLE, bob);
     vm.stopPrank();
     vm.startPrank(bob);
-    wrappedProxyV1.submitMerkleRoot(root, maxDailyEmission);
+    wrappedProxyV1.submitMerkleRoot(root, maxDailyEmission, 0);
     RLPReader.RLPItem[] memory rewards = resultData.toRlpItem().toList();
     RLPReader.RLPItem[] memory proofsEncoded = resultProofs.toRlpItem().toList();
     bytes32[] memory _proof = new bytes32[](proofsEncoded[0].toList().length);
@@ -379,7 +379,7 @@ contract RewardPoolTest is Test {
     vm.startPrank(bob);
     assertEq(weatherXM.balanceOf(address(treasury)), 0);
     uint256 totalRewards = 10246 * 10 ** 18;
-    wrappedProxyV1.submitMerkleRoot(root, totalRewards);
+    wrappedProxyV1.submitMerkleRoot(root, totalRewards, 0);
     assertEq(weatherXM.balanceOf(address(treasury)), maxDailyEmission - totalRewards);
     assertEq(weatherXM.balanceOf(address(wrappedProxyV1)), totalRewards);
     vm.stopPrank();

--- a/test/foundry/RewardsVault.t.sol
+++ b/test/foundry/RewardsVault.t.sol
@@ -159,8 +159,11 @@ contract RewardsVaultTest is Test {
 
     currTs = block.timestamp;
 
-    // Move 2 days ahead and we can pull yesterdays reward's as well
+    // Move 2 days ahead and we can pull twice
     vm.warp(currTs + rewardDistributionPeriod * 2);
+    rewardsVault.pullDailyEmissions();
+    assertEq(wxm.balanceOf(rewardsDistributor), maxDailyEmission * 3);
+
     rewardsVault.pullDailyEmissions();
     assertEq(wxm.balanceOf(rewardsDistributor), maxDailyEmission * 4);
 


### PR DESCRIPTION
## Changes

- The rewards vault will now only emit up to the daily emission amount but will allow to pull `n+1` times if we did not pul for `n` days
- The reward pool will now allow submitting `n+1` Merkle tree hashes if we did not submit for `n`
- When submitting a Merkle root that includes rewards from a boost we need to specify the total rewards that are coming from the boost and these rewards will automatically be pulled from the `rewardsChangeTreasury`

## Checklist

Please make sure to review and check the following before submitting the pull request:

- [x] Unit tests are added or modified to cover the changes.
- [ ] Documentation has been updated to reflect the changes.

