### PR TITLE
chore: remove testing key from config

### DIFF
--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -53,7 +53,7 @@ const hardhatConfig: HardhatUserConfig = {
     arbitrumGoerli: {
       chainId: 421613,
       url: "https://goerli-rollup.arbitrum.io/rpc",
-      accounts: ['0xafd72e8b21617468e50f211f985267ca8eeed3732875e2853e6219d53938b074']
+      accounts: []
     }
     // mumbai: {
     //   url: process.env.NODE_URL || `https://polygon-mumbai.g.alchemy.com/v2/${envConfig.ALCHEMY_API_KEY}`,


### PR DESCRIPTION
## Problem Description

There was a key we used to test in hardhat config

## Solution

Removed testing key from hardhat config to keep the file clean
